### PR TITLE
fix: add route transitions to command menu navigation

### DIFF
--- a/src/components/CommandMenuContext.tsx
+++ b/src/components/CommandMenuContext.tsx
@@ -14,7 +14,7 @@ import type {
   PluginCommandMenuConfig,
 } from 'src/types'
 
-import { Modal, useConfig, useModal, useTranslation } from '@payloadcms/ui'
+import { Modal, useConfig, useModal, useRouteTransition, useTranslation } from '@payloadcms/ui'
 import { ArrowBigUp, ChevronLeft, Command as CommandIcon, Option } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import {
@@ -90,6 +90,7 @@ const CommandMenuComponent: React.FC<{
 
   const { closeMenu, currentPage, groups, items, setPage } = useCommandMenu()
   const router = useRouter()
+  const { startRouteTransition } = useRouteTransition()
   const { t } = useTranslation<CustomTranslationsObject, CustomTranslationsKeys>()
 
   useEffect(() => {
@@ -195,7 +196,7 @@ const CommandMenuComponent: React.FC<{
           })
           break
         case 'link':
-          router.push(item.action.href)
+          startRouteTransition(() => router.push(item.action.href))
           break
         default:
           break
@@ -204,7 +205,7 @@ const CommandMenuComponent: React.FC<{
       setSearch('')
       setPage('main')
     },
-    [router, closeMenu, setPage],
+    [router, closeMenu, setPage, startRouteTransition],
   )
 
   const openSubmenu = useCallback(


### PR DESCRIPTION
Wrap router.push() calls with useRouteTransition to provide immediate visual feedback when navigating via the command menu. This improves UX, especially on slower networks or when loading data-heavy pages.

Changes:
- Import useRouteTransition from @payloadcms/ui
- Wrap navigation calls with startRouteTransition
- Add startRouteTransition to dependency array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized navigation transitions throughout the application to deliver a smoother and more responsive user experience. Route handling has been enhanced to better manage page transitions and provide improved fluidity when navigating between different sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->