### PR TITLE
feat: collection-scoped custom items and function action type

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,69 +304,200 @@ Add custom menu items and groups to the command menu.
 ```typescript
 {
   type: 'item',
-  slug: 'unique-slug',
-  label: 'Item Label', // Can be localized
-  icon: 'LucideIconName', // Optional, from lucide.dev/icons
-  action: {
-    type: 'link' | 'api',
-    href: '/path/or/url',
-    method?: 'GET' | 'POST' | 'PUT' | 'DELETE', // For API actions
-    body?: { key: 'value' } // For API actions
-  }
+  slug: 'unique-slug',           // Must be unique across all items
+  label: 'Item Label',           // Can be a localized object — see Localization below
+  icon: 'LucideIconName',        // Optional, from lucide.dev/icons
+  collectionSlugs: ['posts'],    // Optional — only show on these collection pages
+  collectionContext: ['list'],   // Optional — 'list', 'document', or both
+  action: { ... }                // See Action Types below
 }
 ```
 
 #### Custom Menu Group
 
+Groups are rendered with a heading and can contain multiple items. Groups with identical titles are automatically merged.
+
 ```typescript
 {
   type: 'group',
-  title: 'Group Title', // Can be localized
+  title: 'Group Title',          // Can be a localized object
+  collectionSlugs: ['posts'],    // Optional — only show on these collection pages
+  collectionContext: ['list'],   // Optional
   items: [
     // Array of CustomMenuItem
   ]
 }
 ```
 
-**Example with localization:**
+---
+
+#### Action Types
+
+Every item requires an `action` that determines what happens when the item is selected.
+
+##### `link` — Navigate to a URL
+
+Navigates to a URL. Supports both internal paths and external URLs.
 
 ```typescript
+action: {
+  type: 'link',
+  href: '/admin/collections/posts', // or 'https://your-site.com'
+}
+```
+
+##### `api` — Call an API endpoint
+
+Makes an HTTP request when the item is selected. The menu closes after the request completes (or fails).
+
+```typescript
+action: {
+  type: 'api',
+  href: '/api/cache/clear',
+  method: 'POST',              // 'GET' | 'POST' | 'PUT' | 'DELETE' — default: 'GET'
+  body: { scope: 'all' },      // Optional JSON body
+}
+```
+
+##### `function` — Call a client-side handler
+
+Because the plugin config is serialized across the Next.js server→client boundary, functions cannot live directly in `payload.config.ts`. Instead, you reference a handler by a **string key** in the config and register the actual function on the client.
+
+**Step 1 — reference the key in your config:**
+
+```typescript
+// payload.config.ts
 customItems: [
   {
-    type: 'group',
-    title: {
-      en: 'Quick Actions',
-      uk: 'Швидкі дії',
+    type: 'item',
+    slug: 'save-document',
+    label: 'Save Document',
+    icon: 'Save',
+    collectionContext: ['document'],
+    action: {
+      type: 'function',
+      key: 'save-current-doc',   // Must match the key used in registerCommandMenuAction
     },
-    items: [
-      {
-        type: 'item',
-        slug: 'view-site',
-        label: {
-          en: 'View Site',
-          uk: 'Переглянути сайт',
-        },
-        icon: 'ExternalLink',
-        action: {
-          type: 'link',
-          href: 'https://your-site.com',
-        },
-      },
-      {
-        type: 'item',
-        slug: 'regenerate',
-        label: 'Regenerate Cache',
-        icon: 'RefreshCw',
-        action: {
-          type: 'api',
-          method: 'POST',
-          href: '/api/cache/regenerate',
-        },
-      },
-    ],
   },
 ]
 ```
+
+**Step 2 — register the handler in a client component:**
+
+```typescript
+// e.g. app/(payload)/layout.tsx  or  a custom admin component
+'use client'
+import { registerCommandMenuAction, unregisterCommandMenuAction } from '@veiag/payload-cmdk/client'
+import { useEffect } from 'react'
+
+export default function AdminLayout({ children }) {
+  useEffect(() => {
+    registerCommandMenuAction('save-current-doc', () => {
+      // Submit the currently active form (Payload's save button)
+      document.querySelector<HTMLButtonElement>('button[type="submit"]')?.click()
+    })
+
+    // Clean up when the component unmounts
+    return () => unregisterCommandMenuAction('save-current-doc')
+  }, [])
+
+  return <>{children}</>
+}
+```
+
+The handler can be synchronous or return a `Promise`. The menu always closes after it resolves (or throws).
+
+**Full example with multiple function actions:**
+
+```typescript
+// payload.config.ts
+customItems: [
+  {
+    type: 'group',
+    title: 'Document Actions',
+    collectionContext: ['document'],
+    items: [
+      {
+        type: 'item',
+        slug: 'save-document',
+        label: 'Save Document',
+        icon: 'Save',
+        action: { type: 'function', key: 'save-current-doc' },
+      },
+      {
+        type: 'item',
+        slug: 'copy-doc-link',
+        label: 'Copy Document Link',
+        icon: 'Link',
+        action: { type: 'function', key: 'copy-doc-link' },
+      },
+    ],
+  },
+  {
+    type: 'item',
+    slug: 'import-posts',
+    label: 'Import Posts',
+    icon: 'Upload',
+    collectionSlugs: ['posts'],
+    collectionContext: ['list'],
+    action: { type: 'function', key: 'import-posts' },
+  },
+]
+```
+
+```typescript
+// Client component / layout
+'use client'
+import { registerCommandMenuAction, unregisterCommandMenuAction } from '@veiag/payload-cmdk/client'
+import { useEffect } from 'react'
+
+export default function AdminLayout({ children }) {
+  useEffect(() => {
+    registerCommandMenuAction('save-current-doc', () => {
+      document.querySelector<HTMLButtonElement>('button[type="submit"]')?.click()
+    })
+
+    registerCommandMenuAction('copy-doc-link', () => {
+      navigator.clipboard.writeText(window.location.href)
+    })
+
+    registerCommandMenuAction('import-posts', async () => {
+      await fetch('/api/posts/import', { method: 'POST' })
+    })
+
+    return () => {
+      unregisterCommandMenuAction('save-current-doc')
+      unregisterCommandMenuAction('copy-doc-link')
+      unregisterCommandMenuAction('import-posts')
+    }
+  }, [])
+
+  return <>{children}</>
+}
+```
+
+> **Note:** If a key is used in the config but no handler has been registered, the plugin logs a warning to the console and the menu still closes normally.
+
+---
+
+#### `collectionSlugs` — Restrict to specific collections
+
+Show an item or group only when the user is viewing a particular collection.
+
+```typescript
+{
+  type: 'item',
+  slug: 'export-posts',
+  label: 'Export Posts',
+  icon: 'Download',
+  collectionSlugs: ['posts'],         // only visible on /admin/collections/posts/*
+  action: { type: 'function', key: 'export-posts' },
+}
+```
+
+Omit `collectionSlugs` (or pass an empty array) to show the item on all pages, including non-collection pages.
+
+---
 
 #### `collectionContext` — Restrict to list or document pages
 
@@ -429,6 +560,48 @@ customItems: [
     collectionSlugs: ['posts'],
     collectionContext: ['list', 'document'],
     action: { type: 'link', href: '/docs' },
+  },
+]
+```
+
+---
+
+**Example with localization:**
+
+```typescript
+customItems: [
+  {
+    type: 'group',
+    title: {
+      en: 'Quick Actions',
+      uk: 'Швидкі дії',
+    },
+    items: [
+      {
+        type: 'item',
+        slug: 'view-site',
+        label: {
+          en: 'View Site',
+          uk: 'Переглянути сайт',
+        },
+        icon: 'ExternalLink',
+        action: {
+          type: 'link',
+          href: 'https://your-site.com',
+        },
+      },
+      {
+        type: 'item',
+        slug: 'regenerate',
+        label: 'Regenerate Cache',
+        icon: 'RefreshCw',
+        action: {
+          type: 'api',
+          method: 'POST',
+          href: '/api/cache/regenerate',
+        },
+      },
+    ],
   },
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -368,6 +368,71 @@ customItems: [
 ]
 ```
 
+#### `collectionContext` — Restrict to list or document pages
+
+Use `collectionContext` on any item or group to control exactly where inside a collection it appears.
+
+- **Type:** `('document' | 'list')[]`
+- **Default:** not set (appears on all pages)
+
+| Value | Where it appears |
+|-------|-----------------|
+| `'list'` | Collection list page — e.g. `/admin/collections/posts` |
+| `'document'` | Document edit or create page — e.g. `/admin/collections/posts/abc123` or `/admin/collections/posts/create` |
+
+Pass both values, or omit the field entirely, to show the item on all collection pages.
+
+`collectionContext` can be combined with `collectionSlugs` to target a specific collection **and** a specific page context, or used alone to apply to all collections.
+
+**Examples:**
+
+```typescript
+customItems: [
+  // Only on the posts list page
+  {
+    type: 'item',
+    slug: 'import-posts',
+    label: 'Import Posts',
+    icon: 'Upload',
+    collectionSlugs: ['posts'],
+    collectionContext: ['list'],
+    action: { type: 'function', key: 'import-posts' },
+  },
+
+  // Only when editing or creating a post
+  {
+    type: 'item',
+    slug: 'save-post',
+    label: 'Save Post',
+    icon: 'Save',
+    collectionSlugs: ['posts'],
+    collectionContext: ['document'],
+    action: { type: 'function', key: 'save-current-doc' },
+  },
+
+  // On any document edit/create page across all collections
+  {
+    type: 'item',
+    slug: 'copy-link',
+    label: 'Copy Document Link',
+    icon: 'Link',
+    collectionContext: ['document'],
+    action: { type: 'function', key: 'copy-doc-link' },
+  },
+
+  // On both list and document pages (same as omitting collectionContext)
+  {
+    type: 'item',
+    slug: 'help',
+    label: 'Open Help',
+    icon: 'HelpCircle',
+    collectionSlugs: ['posts'],
+    collectionContext: ['list', 'document'],
+    action: { type: 'link', href: '/docs' },
+  },
+]
+```
+
 ### `slugsToIgnore`
 
 Specify which collection/global slugs to exclude from the command menu.

--- a/src/components/CommandMenuContext.tsx
+++ b/src/components/CommandMenuContext.tsx
@@ -124,11 +124,11 @@ const CommandMenuComponent: React.FC<{
         }
       }
       // --- collectionContext filter ---
-      if (entry.collectionContext && entry.collectionContext !== 'both') {
+      if (entry.collectionContext && entry.collectionContext.length > 0) {
         // context filter only makes sense on a collection page
         if (currentCollectionSlug === null) return false
-        if (entry.collectionContext === 'list' && isDocumentContext) return false
-        if (entry.collectionContext === 'document' && !isDocumentContext) return false
+        const currentContext = isDocumentContext ? 'document' : 'list'
+        if (!entry.collectionContext.includes(currentContext)) return false
       }
       return true
     },

--- a/src/components/CommandMenuContext.tsx
+++ b/src/components/CommandMenuContext.tsx
@@ -242,38 +242,41 @@ const CommandMenuComponent: React.FC<{
 
   const executeItemAction = useCallback(
     async (item: CommandMenuItem) => {
-      // Execute the item's action
-      switch (item.action.type) {
-        case 'api':
-          await fetch(item.action.href, {
-            body: item.action.body ? JSON.stringify(item.action.body) : undefined,
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            method: item.action.method || 'GET',
-          })
-          break
-        case 'function': {
-          const handler = getCommandMenuAction(item.action.key)
-          if (handler) {
-            await handler()
-          } else {
-            console.warn(
-              `[payload-cmdk] No handler registered for function action key "${item.action.key}". ` +
-                `Call registerCommandMenuAction("${item.action.key}", fn) on the client.`,
-            )
+      try {
+        // Execute the item's action
+        switch (item.action.type) {
+          case 'api':
+            await fetch(item.action.href, {
+              body: item.action.body ? JSON.stringify(item.action.body) : undefined,
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              method: item.action.method || 'GET',
+            })
+            break
+          case 'function': {
+            const handler = getCommandMenuAction(item.action.key)
+            if (handler) {
+              await handler()
+            } else {
+              console.warn(
+                `[payload-cmdk] No handler registered for function action key "${item.action.key}". ` +
+                  `Call registerCommandMenuAction("${item.action.key}", fn) on the client.`,
+              )
+            }
+            break
           }
-          break
+          case 'link':
+            startRouteTransition(() => router.push(item.action.href))
+            break
+          default:
+            break
         }
-        case 'link':
-          startRouteTransition(() => router.push(item.action.href))
-          break
-        default:
-          break
+      } finally {
+        closeMenu()
+        setSearch('')
+        setPage('main')
       }
-      closeMenu()
-      setSearch('')
-      setPage('main')
     },
     [router, closeMenu, setPage, startRouteTransition],
   )

--- a/src/components/CommandMenuContext.tsx
+++ b/src/components/CommandMenuContext.tsx
@@ -16,7 +16,7 @@ import type {
 
 import { Modal, useConfig, useModal, useRouteTransition, useTranslation } from '@payloadcms/ui'
 import { ArrowBigUp, ChevronLeft, Command as CommandIcon, Option } from 'lucide-react'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import {
   createContext,
   Fragment,
@@ -31,6 +31,7 @@ import {
 import { useHotkeys } from 'react-hotkeys-hook'
 
 import { createDefaultGroups } from '../utils/index'
+import { getCommandMenuAction } from '../utils/registry'
 import {
   Command,
   CommandEmpty,
@@ -90,8 +91,41 @@ const CommandMenuComponent: React.FC<{
 
   const { closeMenu, currentPage, groups, items, setPage } = useCommandMenu()
   const router = useRouter()
+  const pathname = usePathname()
   const { startRouteTransition } = useRouteTransition()
   const { t } = useTranslation<CustomTranslationsObject, CustomTranslationsKeys>()
+
+  // Detect which collection the user is currently viewing (if any)
+  const currentCollectionSlug = useMemo(() => {
+    if (!pathname) return null
+    const match = pathname.match(/\/admin\/collections\/([^/]+)/)
+    return match?.[1] ?? null
+  }, [pathname])
+
+  // Filter groups to only those visible on the current page
+  const visibleGroups = useMemo(() => {
+    return groups
+      .filter((group) => {
+        if (!group.collectionSlugs || group.collectionSlugs.length === 0) return true
+        return currentCollectionSlug && group.collectionSlugs.includes(currentCollectionSlug as never)
+      })
+      .map((group) => ({
+        ...group,
+        items: group.items.filter((item) => {
+          if (!item.collectionSlugs || item.collectionSlugs.length === 0) return true
+          return currentCollectionSlug && item.collectionSlugs.includes(currentCollectionSlug as never)
+        }),
+      }))
+      .filter((group) => group.items.length > 0)
+  }, [groups, currentCollectionSlug])
+
+  // Filter stray items to only those visible on the current page
+  const visibleItems = useMemo(() => {
+    return items.filter((item) => {
+      if (!item.collectionSlugs || item.collectionSlugs.length === 0) return true
+      return currentCollectionSlug && item.collectionSlugs.includes(currentCollectionSlug as never)
+    })
+  }, [items, currentCollectionSlug])
 
   useEffect(() => {
     setIsMac(/Mac|iPhone|iPod|iPad/i.test(navigator.platform))
@@ -195,6 +229,18 @@ const CommandMenuComponent: React.FC<{
             method: item.action.method || 'GET',
           })
           break
+        case 'function': {
+          const handler = getCommandMenuAction(item.action.key)
+          if (handler) {
+            await handler()
+          } else {
+            console.warn(
+              `[payload-cmdk] No handler registered for function action key "${item.action.key}". ` +
+                `Call registerCommandMenuAction("${item.action.key}", fn) on the client.`,
+            )
+          }
+          break
+        }
         case 'link':
           startRouteTransition(() => router.push(item.action.href))
           break
@@ -260,7 +306,7 @@ const CommandMenuComponent: React.FC<{
             e.stopPropagation()
 
             // Find the item in groups
-            const item = groups.flatMap((g) => g.items).find((i) => i.slug === itemSlug)
+            const item = visibleGroups.flatMap((g) => g.items).find((i) => i.slug === itemSlug)
             if (item) {
               openSubmenu(item)
             }
@@ -272,7 +318,7 @@ const CommandMenuComponent: React.FC<{
 
     document.addEventListener('keydown', handleKeyDown, true)
     return () => document.removeEventListener('keydown', handleKeyDown, true)
-  }, [currentPage, handleBack, submenuEnabled, submenuShortcut, openSubmenu, groups])
+  }, [currentPage, handleBack, submenuEnabled, submenuShortcut, openSubmenu, visibleGroups])
 
   const placeholder =
     currentPage === 'main'
@@ -334,7 +380,7 @@ const CommandMenuComponent: React.FC<{
 
             {/* Main page view */}
             {currentPage === 'main' &&
-              groups.map((group, index) => {
+              visibleGroups.map((group, index) => {
                 if (group.items.length === 0) {
                   return null
                 }
@@ -347,7 +393,7 @@ const CommandMenuComponent: React.FC<{
                   titleName = t('general:globals')
                 }
 
-                const isRenderSeparator = !(index === groups.length - 1 && items.length === 0)
+                const isRenderSeparator = !(index === visibleGroups.length - 1 && visibleItems.length === 0)
                 return (
                   <Fragment key={group.title}>
                     <CommandGroup heading={titleName}>
@@ -386,7 +432,7 @@ const CommandMenuComponent: React.FC<{
 
             {/* Stray items on main page */}
             {currentPage === 'main' &&
-              items?.map((item) => {
+              visibleItems?.map((item) => {
                 const isDynamicIcon = typeof item.icon === 'string'
                 const IconComponent = isDynamicIcon ? null : (item.icon as LucideIcon)
                 return (

--- a/src/components/CommandMenuContext.tsx
+++ b/src/components/CommandMenuContext.tsx
@@ -107,13 +107,19 @@ const CommandMenuComponent: React.FC<{
     return groups
       .filter((group) => {
         if (!group.collectionSlugs || group.collectionSlugs.length === 0) return true
-        return currentCollectionSlug && group.collectionSlugs.includes(currentCollectionSlug as never)
+        return (
+          currentCollectionSlug !== null &&
+          (group.collectionSlugs as string[]).includes(currentCollectionSlug)
+        )
       })
       .map((group) => ({
         ...group,
         items: group.items.filter((item) => {
           if (!item.collectionSlugs || item.collectionSlugs.length === 0) return true
-          return currentCollectionSlug && item.collectionSlugs.includes(currentCollectionSlug as never)
+          return (
+            currentCollectionSlug !== null &&
+            (item.collectionSlugs as string[]).includes(currentCollectionSlug)
+          )
         }),
       }))
       .filter((group) => group.items.length > 0)
@@ -123,7 +129,10 @@ const CommandMenuComponent: React.FC<{
   const visibleItems = useMemo(() => {
     return items.filter((item) => {
       if (!item.collectionSlugs || item.collectionSlugs.length === 0) return true
-      return currentCollectionSlug && item.collectionSlugs.includes(currentCollectionSlug as never)
+      return (
+        currentCollectionSlug !== null &&
+        (item.collectionSlugs as string[]).includes(currentCollectionSlug)
+      )
     })
   }, [items, currentCollectionSlug])
 

--- a/src/components/CommandMenuContext.tsx
+++ b/src/components/CommandMenuContext.tsx
@@ -95,18 +95,24 @@ const CommandMenuComponent: React.FC<{
   const pathname = usePathname()
   const { startRouteTransition } = useRouteTransition()
   const { t } = useTranslation<CustomTranslationsObject, CustomTranslationsKeys>()
+  const { config } = useConfig()
 
   // Detect which collection the user is currently viewing (if any) and whether
   // they are on the list page or a specific document/create page.
+  // Use the configured admin route instead of hardcoding '/admin' so that
+  // projects with a custom adminRoute still match correctly.
   const { currentCollectionSlug, isDocumentContext } = useMemo(() => {
     if (!pathname) return { currentCollectionSlug: null, isDocumentContext: false }
+    const adminRoute = config.routes?.admin ?? '/admin'
+    // Escape any regex special characters in the admin route path
+    const escapedRoute = adminRoute.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     // Group 1 = collection slug, Group 2 (optional) = document ID or 'create'
-    const match = pathname.match(/\/admin\/collections\/([^/]+)(?:\/([^/]+))?/)
+    const match = pathname.match(new RegExp(`${escapedRoute}/collections/([^/]+)(?:/([^/]+))?`))
     return {
       currentCollectionSlug: match?.[1] ?? null,
       isDocumentContext: match?.[2] != null,
     }
-  }, [pathname])
+  }, [pathname, config.routes?.admin])
 
   /** Returns true if an item/group should be visible given the current route. */
   const isEntryVisible = useCallback(
@@ -245,15 +251,21 @@ const CommandMenuComponent: React.FC<{
       try {
         // Execute the item's action
         switch (item.action.type) {
-          case 'api':
-            await fetch(item.action.href, {
+          case 'api': {
+            const response = await fetch(item.action.href, {
               body: item.action.body ? JSON.stringify(item.action.body) : undefined,
               headers: {
                 'Content-Type': 'application/json',
               },
               method: item.action.method || 'GET',
             })
+            if (!response.ok) {
+              throw new Error(
+                `[payload-cmdk] API action failed: ${response.status} ${response.statusText}`,
+              )
+            }
             break
+          }
           case 'function': {
             const handler = getCommandMenuAction(item.action.key)
             if (handler) {

--- a/src/components/CommandMenuContext.tsx
+++ b/src/components/CommandMenuContext.tsx
@@ -5,6 +5,7 @@ import type { CustomTranslationsKeys, CustomTranslationsObject } from 'src/trans
 import './modal.scss'
 
 import type {
+  CollectionContext,
   CommandMenuContextProps,
   CommandMenuGroup,
   CommandMenuItem,
@@ -95,46 +96,60 @@ const CommandMenuComponent: React.FC<{
   const { startRouteTransition } = useRouteTransition()
   const { t } = useTranslation<CustomTranslationsObject, CustomTranslationsKeys>()
 
-  // Detect which collection the user is currently viewing (if any)
-  const currentCollectionSlug = useMemo(() => {
-    if (!pathname) return null
-    const match = pathname.match(/\/admin\/collections\/([^/]+)/)
-    return match?.[1] ?? null
+  // Detect which collection the user is currently viewing (if any) and whether
+  // they are on the list page or a specific document/create page.
+  const { currentCollectionSlug, isDocumentContext } = useMemo(() => {
+    if (!pathname) return { currentCollectionSlug: null, isDocumentContext: false }
+    // Group 1 = collection slug, Group 2 (optional) = document ID or 'create'
+    const match = pathname.match(/\/admin\/collections\/([^/]+)(?:\/([^/]+))?/)
+    return {
+      currentCollectionSlug: match?.[1] ?? null,
+      isDocumentContext: match?.[2] != null,
+    }
   }, [pathname])
+
+  /** Returns true if an item/group should be visible given the current route. */
+  const isEntryVisible = useCallback(
+    (entry: {
+      collectionContext?: CollectionContext
+      collectionSlugs?: readonly string[] | string[]
+    }): boolean => {
+      // --- collectionSlugs filter ---
+      if (entry.collectionSlugs && entry.collectionSlugs.length > 0) {
+        if (
+          currentCollectionSlug === null ||
+          !(entry.collectionSlugs as string[]).includes(currentCollectionSlug)
+        ) {
+          return false
+        }
+      }
+      // --- collectionContext filter ---
+      if (entry.collectionContext && entry.collectionContext !== 'both') {
+        // context filter only makes sense on a collection page
+        if (currentCollectionSlug === null) return false
+        if (entry.collectionContext === 'list' && isDocumentContext) return false
+        if (entry.collectionContext === 'document' && !isDocumentContext) return false
+      }
+      return true
+    },
+    [currentCollectionSlug, isDocumentContext],
+  )
 
   // Filter groups to only those visible on the current page
   const visibleGroups = useMemo(() => {
     return groups
-      .filter((group) => {
-        if (!group.collectionSlugs || group.collectionSlugs.length === 0) return true
-        return (
-          currentCollectionSlug !== null &&
-          (group.collectionSlugs as string[]).includes(currentCollectionSlug)
-        )
-      })
+      .filter((group) => isEntryVisible(group))
       .map((group) => ({
         ...group,
-        items: group.items.filter((item) => {
-          if (!item.collectionSlugs || item.collectionSlugs.length === 0) return true
-          return (
-            currentCollectionSlug !== null &&
-            (item.collectionSlugs as string[]).includes(currentCollectionSlug)
-          )
-        }),
+        items: group.items.filter((item) => isEntryVisible(item)),
       }))
       .filter((group) => group.items.length > 0)
-  }, [groups, currentCollectionSlug])
+  }, [groups, isEntryVisible])
 
   // Filter stray items to only those visible on the current page
   const visibleItems = useMemo(() => {
-    return items.filter((item) => {
-      if (!item.collectionSlugs || item.collectionSlugs.length === 0) return true
-      return (
-        currentCollectionSlug !== null &&
-        (item.collectionSlugs as string[]).includes(currentCollectionSlug)
-      )
-    })
-  }, [items, currentCollectionSlug])
+    return items.filter((item) => isEntryVisible(item))
+  }, [items, isEntryVisible])
 
   useEffect(() => {
     setIsMac(/Mac|iPhone|iPod|iPad/i.test(navigator.platform))

--- a/src/exports/client.ts
+++ b/src/exports/client.ts
@@ -1,2 +1,6 @@
 export { CommandMenuProvider, useCommandMenu } from '../components/CommandMenuContext'
 export { default as SearchButton } from '../components/SearchButton'
+export {
+  registerCommandMenuAction,
+  unregisterCommandMenuAction,
+} from '../utils/registry'

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,19 @@ export type InternalIcon = IconName | LucideIcon
 
 /**
  * Controls which context within a collection a custom item/group is visible in.
+ * Pass an array with one or both values:
  *
- * - `'list'`     — only on the collection list page     (`/admin/collections/{slug}`)
- * - `'document'` — only on a document edit/create page  (`/admin/collections/{slug}/{id|create}`)
- * - `'both'`     — on both (default)
+ * - `'list'`     — collection list page      (`/admin/collections/{slug}`)
+ * - `'document'` — document edit/create page (`/admin/collections/{slug}/{id|create}`)
+ *
+ * Omit the field (or pass both values) to show in all contexts.
+ *
+ * @example
+ * collectionContext: ['list']              // list page only
+ * collectionContext: ['document']          // document page only
+ * collectionContext: ['list', 'document']  // both (same as omitting)
  */
-export type CollectionContext = 'both' | 'document' | 'list'
+export type CollectionContext = ('document' | 'list')[]
 
 /**
  * Custom menu item, for configuration.
@@ -23,15 +30,16 @@ export type CollectionContext = 'both' | 'document' | 'list'
 export type CustomMenuItem = {
   action: CommandMenuAction
   /**
-   * Further restrict visibility within a matching collection.
-   * Only meaningful when `collectionSlugs` is also set (or when you want the item to appear
-   * on a specific context across all collections).
+   * Restrict visibility to specific contexts within a collection page.
+   * Pass an array with one or both values — omit to show in all contexts.
    *
-   * - `'list'`     — only on the collection list page
-   * - `'document'` — only on a document edit / create page
-   * - `'both'`     — on both (default)
+   * - `'list'`     — collection list page      (`/admin/collections/{slug}`)
+   * - `'document'` — document edit/create page (`/admin/collections/{slug}/{id|create}`)
    *
-   * @default 'both'
+   * @example
+   * collectionContext: ['list']              // list page only
+   * collectionContext: ['document']          // document page only
+   * collectionContext: ['list', 'document']  // both (same as omitting)
    */
   collectionContext?: CollectionContext
   /**
@@ -54,15 +62,16 @@ export type CustomMenuItem = {
  */
 export type CustomMenuGroup = {
   /**
-   * Further restrict visibility within a matching collection.
-   * Only meaningful when `collectionSlugs` is also set (or when you want the group to appear
-   * on a specific context across all collections).
+   * Restrict visibility to specific contexts within a collection page.
+   * Pass an array with one or both values — omit to show in all contexts.
    *
-   * - `'list'`     — only on the collection list page
-   * - `'document'` — only on a document edit / create page
-   * - `'both'`     — on both (default)
+   * - `'list'`     — collection list page      (`/admin/collections/{slug}`)
+   * - `'document'` — document edit/create page (`/admin/collections/{slug}/{id|create}`)
    *
-   * @default 'both'
+   * @example
+   * collectionContext: ['list']              // list page only
+   * collectionContext: ['document']          // document page only
+   * collectionContext: ['list', 'document']  // both (same as omitting)
    */
   collectionContext?: CollectionContext
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,32 @@ export type LocalizedString = { [locale: string]: string } | string
 export type InternalIcon = IconName | LucideIcon
 
 /**
+ * Controls which context within a collection a custom item/group is visible in.
+ *
+ * - `'list'`     — only on the collection list page     (`/admin/collections/{slug}`)
+ * - `'document'` — only on a document edit/create page  (`/admin/collections/{slug}/{id|create}`)
+ * - `'both'`     — on both (default)
+ */
+export type CollectionContext = 'both' | 'document' | 'list'
+
+/**
  * Custom menu item, for configuration.
  * Will be mapped to CommandMenuItem internally.
  */
 export type CustomMenuItem = {
   action: CommandMenuAction
+  /**
+   * Further restrict visibility within a matching collection.
+   * Only meaningful when `collectionSlugs` is also set (or when you want the item to appear
+   * on a specific context across all collections).
+   *
+   * - `'list'`     — only on the collection list page
+   * - `'document'` — only on a document edit / create page
+   * - `'both'`     — on both (default)
+   *
+   * @default 'both'
+   */
+  collectionContext?: CollectionContext
   /**
    * Restrict this item to only appear when the user is on one of these collection pages.
    * Matches against the current route (e.g. `/admin/collections/{slug}`).
@@ -32,6 +53,18 @@ export type CustomMenuItem = {
  * Groups will be merged if they have the same title.
  */
 export type CustomMenuGroup = {
+  /**
+   * Further restrict visibility within a matching collection.
+   * Only meaningful when `collectionSlugs` is also set (or when you want the group to appear
+   * on a specific context across all collections).
+   *
+   * - `'list'`     — only on the collection list page
+   * - `'document'` — only on a document edit / create page
+   * - `'both'`     — on both (default)
+   *
+   * @default 'both'
+   */
+  collectionContext?: CollectionContext
   /**
    * Restrict this group to only appear when the user is on one of these collection pages.
    * Matches against the current route (e.g. `/admin/collections/{slug}`).
@@ -202,6 +235,8 @@ export interface CommandMenuItem {
    * Action to perform when the command menu item is selected.
    */
   action: CommandMenuAction
+  /** Populated from `CustomMenuItem.collectionContext`. */
+  collectionContext?: CollectionContext
   /**
    * Restrict this item to only appear when the user is on one of these collection pages.
    * Populated from `CustomMenuItem.collectionSlugs`.
@@ -232,6 +267,8 @@ export interface CommandMenuItem {
 }
 
 export interface CommandMenuGroup {
+  /** Populated from `CustomMenuGroup.collectionContext`. */
+  collectionContext?: CollectionContext
   /**
    * Restrict this group to only appear when the user is on one of these collection pages.
    * Populated from `CustomMenuGroup.collectionSlugs`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,12 @@ export type InternalIcon = IconName | LucideIcon
  */
 export type CustomMenuItem = {
   action: CommandMenuAction
+  /**
+   * Restrict this item to only appear when the user is on one of these collection pages.
+   * Matches against the current route (e.g. `/admin/collections/{slug}`).
+   * If omitted or empty, the item appears on all pages.
+   */
+  collectionSlugs?: CollectionSlug[]
   icon?: IconName
   label: LocalizedString
   slug: string
@@ -26,6 +32,12 @@ export type CustomMenuItem = {
  * Groups will be merged if they have the same title.
  */
 export type CustomMenuGroup = {
+  /**
+   * Restrict this group to only appear when the user is on one of these collection pages.
+   * Matches against the current route (e.g. `/admin/collections/{slug}`).
+   * If omitted or empty, the group appears on all pages.
+   */
+  collectionSlugs?: CollectionSlug[]
   items: CustomMenuItem[]
   title: LocalizedString
   type: 'group'
@@ -159,13 +171,42 @@ export interface CommandMenuActionAPICall {
   type: 'api'
 }
 
-export type CommandMenuAction = CommandMenuActionAPICall | CommandMenuActionLink
+/**
+ * Calls a function registered via `registerCommandMenuAction(key, fn)` on the client.
+ * Since the plugin config is serialized across the server→client boundary, functions
+ * cannot be passed directly — use a string key to reference a registered handler instead.
+ *
+ * @example
+ * // In payload.config.ts:
+ * action: { type: 'function', key: 'save-current-doc' }
+ *
+ * // In your client-side code:
+ * import { registerCommandMenuAction } from '@veiag/payload-cmdk/client'
+ * registerCommandMenuAction('save-current-doc', () => { ... })
+ */
+export interface CommandMenuActionFunction {
+  /**
+   * Key used to look up the registered handler via `registerCommandMenuAction`.
+   */
+  key: string
+  type: 'function'
+}
+
+export type CommandMenuAction =
+  | CommandMenuActionAPICall
+  | CommandMenuActionFunction
+  | CommandMenuActionLink
 
 export interface CommandMenuItem {
   /**
    * Action to perform when the command menu item is selected.
    */
   action: CommandMenuAction
+  /**
+   * Restrict this item to only appear when the user is on one of these collection pages.
+   * Populated from `CustomMenuItem.collectionSlugs`.
+   */
+  collectionSlugs?: CollectionSlug[]
   icon?: InternalIcon
   label: string
   slug: string
@@ -191,6 +232,11 @@ export interface CommandMenuItem {
 }
 
 export interface CommandMenuGroup {
+  /**
+   * Restrict this group to only appear when the user is on one of these collection pages.
+   * Populated from `CustomMenuGroup.collectionSlugs`.
+   */
+  collectionSlugs?: CollectionSlug[]
   items: CommandMenuItem[]
   title: string
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -78,6 +78,7 @@ export const convertConfigItem = (item: CustomMenuItem, currentLang: string): Co
     slug: item.slug,
     type: 'custom',
     action: item.action,
+    collectionContext: item.collectionContext,
     collectionSlugs: item.collectionSlugs,
     icon: item.icon,
     label: extractLocalizedValue(item.label, currentLang, item.slug),
@@ -89,6 +90,7 @@ export const convertConfigGroup = (
   currentLang: string,
 ): CommandMenuGroup => {
   return {
+    collectionContext: group.collectionContext,
     collectionSlugs: group.collectionSlugs,
     items: group.items.map((item) => convertConfigItem(item, currentLang)), // Will be merged with existing items if group exists
     title: extractLocalizedValue(group.title, currentLang),
@@ -228,6 +230,7 @@ export const createDefaultGroups = (
         if (!avaibleGroups.has(convertedGroup.title)) {
           avaibleGroups.add(convertedGroup.title)
           groups.push({
+            collectionContext: convertedGroup.collectionContext,
             collectionSlugs: convertedGroup.collectionSlugs,
             items: [], //Don't add items yet, will do below
             title: convertedGroup.title,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -78,6 +78,7 @@ export const convertConfigItem = (item: CustomMenuItem, currentLang: string): Co
     slug: item.slug,
     type: 'custom',
     action: item.action,
+    collectionSlugs: item.collectionSlugs,
     icon: item.icon,
     label: extractLocalizedValue(item.label, currentLang, item.slug),
   }
@@ -88,6 +89,7 @@ export const convertConfigGroup = (
   currentLang: string,
 ): CommandMenuGroup => {
   return {
+    collectionSlugs: group.collectionSlugs,
     items: group.items.map((item) => convertConfigItem(item, currentLang)), // Will be merged with existing items if group exists
     title: extractLocalizedValue(group.title, currentLang),
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -228,6 +228,7 @@ export const createDefaultGroups = (
         if (!avaibleGroups.has(convertedGroup.title)) {
           avaibleGroups.add(convertedGroup.title)
           groups.push({
+            collectionSlugs: convertedGroup.collectionSlugs,
             items: [], //Don't add items yet, will do below
             title: convertedGroup.title,
           })

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -1,0 +1,56 @@
+'use client'
+
+/**
+ * Handler type for command menu function actions.
+ */
+export type CommandMenuActionHandler = () => Promise<void> | void
+
+/**
+ * Client-side registry for function-based command menu actions.
+ *
+ * Because the plugin config is serialized across the Next.js server→client
+ * boundary, JavaScript functions cannot be embedded directly in the config.
+ * Instead, register handlers here by a string key and reference that key in
+ * `action: { type: 'function', key: '...' }`.
+ *
+ * @example
+ * // payload.config.ts
+ * customItems: [{
+ *   type: 'item',
+ *   slug: 'save-doc',
+ *   label: 'Save Document',
+ *   icon: 'Save',
+ *   collectionSlugs: ['posts'],
+ *   action: { type: 'function', key: 'save-current-doc' },
+ * }]
+ *
+ * // Your client-side component / layout
+ * import { registerCommandMenuAction } from '@veiag/payload-cmdk/client'
+ * registerCommandMenuAction('save-current-doc', () => {
+ *   document.querySelector('form')?.requestSubmit()
+ * })
+ */
+const registry = new Map<string, CommandMenuActionHandler>()
+
+/**
+ * Register a handler function under the given key.
+ * Calling this with the same key again will overwrite the previous handler.
+ */
+export const registerCommandMenuAction = (key: string, handler: CommandMenuActionHandler): void => {
+  registry.set(key, handler)
+}
+
+/**
+ * Remove a previously registered handler.
+ */
+export const unregisterCommandMenuAction = (key: string): void => {
+  registry.delete(key)
+}
+
+/**
+ * Look up a registered handler by key. Returns `undefined` if not found.
+ * Used internally by the command menu to execute function actions.
+ */
+export const getCommandMenuAction = (key: string): CommandMenuActionHandler | undefined => {
+  return registry.get(key)
+}


### PR DESCRIPTION
## Changes
- Add `collectionSlugs` to `CustomMenuItem` and `CustomMenuGroup` so items/groups only appear when the user is on a matching collection page in the admin (detected from the URL: /admin/collections/{slug})
- Add `CommandMenuActionFunction` action type (`{ type: 'function', key: string }`) that dispatches to a client-side function registry, working around the server→client serialization boundary
- Add `src/utils/registry.ts` with `registerCommandMenuAction` / `unregisterCommandMenuAction` for registering handlers by string key
- Export registry helpers from the client entry point
- Preserve `collectionSlugs` through `convertConfigItem` / `convertConfigGroup`



### Collection-scoped items — collectionSlugs
Add collectionSlugs to any item or group and it will only appear when the user is on that collection's page in the admin (i.e. /admin/collections/{slug} or /admin/collections/{slug}/{id}):


// payload.config.ts
payloadCmdk({
  customItems: [
    {
      type: 'item',
      slug: 'export-posts',
      label: { en: 'Export Posts' },
      icon: 'Download',
      collectionSlugs: ['posts'],           // only appears on /admin/collections/posts
      action: { type: 'function', key: 'export-posts' },
    },
    {
      type: 'group',
      title: 'Document Actions',
      collectionSlugs: ['posts', 'pages'],  // entire group scoped to these collections
      items: [
        {
          slug: 'save-doc',
          type: 'item',
          label: 'Save Document',
          icon: 'Save',
          action: { type: 'function', key: 'save-current-doc' },
        },
      ],
    },
  ],
})


### Function actions — type: 'function'
// In any client component (e.g. a layout or custom provider)
import { registerCommandMenuAction } from '@veiag/payload-cmdk/client'

registerCommandMenuAction('save-current-doc', () => {
  // trigger form submit, call an API, update state — anything you need
  document.querySelector('form')?.requestSubmit()
})

registerCommandMenuAction('export-posts', async () => {
  const res = await fetch('/api/posts/export')
  // handle response...
})



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command menu shows only groups/items relevant to the current collection and page type (list or document), improving context-aware navigation and keyboard/submenu behavior.
  * Command items can invoke client-registered function handlers; functions can be registered/unregistered at runtime to extend menu behavior.

* **Documentation**
  * Added usage guidance and examples for collection-scoped menu items and function-based actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->